### PR TITLE
MarkDownRendering Atomic 컴포넌트 추가

### DIFF
--- a/src/common/Organisms/MarkDownRendering/index.tsx
+++ b/src/common/Organisms/MarkDownRendering/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import remark from "remark";
 import breaks from "remark-breaks";
 import htmlPlugin from "remark-html";
-import htmlParser from "html-react-parser";
+import reactParser from "html-react-parser";
 
 import prismPlugin from "@utils/modules/prism-plugin";
 import * as S from "./style";
@@ -27,7 +27,7 @@ const MarkDownRendering: React.FC<MarkDownRenderingProps> = ({ markDownText }) =
 
   return (
     <>
-      <S.MarkdownWrapper className="atom-one-dark">{htmlParser(html)}</S.MarkdownWrapper>
+      <S.MarkdownWrapper className="atom-one-dark">{reactParser(html)}</S.MarkdownWrapper>
     </>
   );
 };

--- a/src/common/Organisms/MarkDownRendering/index.tsx
+++ b/src/common/Organisms/MarkDownRendering/index.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from "react";
+import remark from "remark";
+import breaks from "remark-breaks";
+import htmlPlugin from "remark-html";
+import htmlParser from "html-react-parser";
+
+import prismPlugin from "@utils/modules/prism-plugin";
+import * as S from "./style";
+
+interface MarkDownRenderingProps {
+  markDownText: string;
+}
+
+const MarkDownRendering: React.FC<MarkDownRenderingProps> = ({ markDownText }) => {
+  const [html, setHtml] = useState("");
+
+  useEffect(() => {
+    remark()
+      .use(prismPlugin)
+      .use(breaks)
+      .use(htmlPlugin)
+      .process(markDownText, (_, file) => {
+        const textResult = String(file);
+        setHtml(textResult);
+      });
+  }, [markDownText]);
+
+  return (
+    <>
+      <S.MarkdownWrapper className="atom-one-dark">{htmlParser(html)}</S.MarkdownWrapper>
+    </>
+  );
+};
+
+export default MarkDownRendering;

--- a/src/common/Organisms/MarkDownRendering/style.ts
+++ b/src/common/Organisms/MarkDownRendering/style.ts
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+import prismTheme from "@utils/styles/atom-one-dark";
+
+export const MarkdownWrapper = styled.div`
+  font-size: 1.125rem;
+  color: rgb(34, 36, 38);
+  line-height: 1.7;
+  letter-spacing: -0.004em;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+  &.atom-one-dark {
+    ${prismTheme["atom-one-dark"]}
+    pre {
+      color: rgb(36, 41, 46);
+      background: #313440;
+    }
+  }
+  pre {
+    margin: 1rem 0;
+    padding: 1.2rem;
+    font-size: 1rem;
+    border-radius: 4px;
+    line-height: 1.5;
+    overflow-x: auto;
+    letter-spacing: 0px;
+  }
+  p {
+    display: block;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+  }
+  img {
+    display: block;
+    margin: 3rem auto;
+    max-width: 100%;
+    height: auto;
+  }
+`;

--- a/src/utils/modules/prism-plugin.js
+++ b/src/utils/modules/prism-plugin.js
@@ -1,0 +1,27 @@
+import visit from "unist-util-visit";
+import Prism from "prismjs";
+import "prismjs/components/prism-javascript";
+
+export default function attacher({ include, exclude } = {}) {
+  function visitor(node) {
+    const { lang } = node;
+    let { data } = node;
+
+    if (!lang || (include && include.indexOf(lang) === -1) || (exclude && exclude.indexOf(lang) !== -1)) {
+      return;
+    }
+    if (!data) {
+      data = {};
+      node.data = data;
+    }
+    if (!data.hProperties) {
+      data.hProperties = {};
+    }
+
+    const highlighted = Prism.highlight(node.value, Prism.languages[lang] || Prism.languages.markup);
+    node.type = "html";
+    node.value = `<pre><code class="language-${lang}">${highlighted}</code></pre>`;
+  }
+
+  return (ast) => visit(ast, "code", visitor);
+}

--- a/src/utils/styles/atom-one-dark.ts
+++ b/src/utils/styles/atom-one-dark.ts
@@ -1,0 +1,158 @@
+import { css } from "styled-components";
+
+const prismTheme = {
+  "atom-one-dark": css`
+    code[class*="language-"],
+    pre[class*="language-"] {
+      color: #abb2bf;
+      background: none;
+      font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+      text-align: left;
+      white-space: pre;
+      word-spacing: normal;
+      word-break: normal;
+      word-wrap: normal;
+      line-height: 1.5;
+      -moz-tab-size: 4;
+      -o-tab-size: 4;
+      tab-size: 4;
+      -webkit-hyphens: none;
+      -moz-hyphens: none;
+      -ms-hyphens: none;
+      hyphens: none;
+    }
+    pre[class*="language-"]::-moz-selection,
+    pre[class*="language-"] ::-moz-selection,
+    code[class*="language-"]::-moz-selection,
+    code[class*="language-"] ::-moz-selection {
+      text-shadow: none;
+      background: #383e49;
+    }
+    pre[class*="language-"]::selection,
+    pre[class*="language-"] ::selection,
+    code[class*="language-"]::selection,
+    code[class*="language-"] ::selection {
+      text-shadow: none;
+      background: #9aa2b1;
+    }
+    @media print {
+      code[class*="language-"],
+      pre[class*="language-"] {
+        text-shadow: none;
+      }
+    }
+    /* Code blocks */
+    pre[class*="language-"] {
+      padding: 1em;
+      margin: 0.5em 0;
+      overflow: auto;
+    }
+    :not(pre) > code[class*="language-"],
+    pre[class*="language-"] {
+      background: #282c34;
+    }
+    /* Inline code */
+    :not(pre) > code[class*="language-"] {
+      padding: 0.1em;
+      border-radius: 0.3em;
+      white-space: normal;
+    }
+    .token.comment,
+    .token.prolog,
+    .token.doctype,
+    .token.cdata {
+      color: #5c6370;
+    }
+    .token.punctuation {
+      color: #abb2bf;
+    }
+    .token.selector,
+    .token.tag {
+      color: #e06c75;
+    }
+    .token.property,
+    .token.boolean,
+    .token.number,
+    .token.constant,
+    .token.symbol,
+    .token.attr-name,
+    .token.deleted {
+      color: #d19a66;
+    }
+    .token.string,
+    .token.char,
+    .token.attr-value,
+    .token.builtin,
+    .token.inserted {
+      color: #98c379;
+    }
+    .token.operator,
+    .token.entity,
+    .token.url,
+    .language-css .token.string,
+    .style .token.string {
+      color: #56b6c2;
+    }
+    .token.atrule,
+    .token.keyword {
+      color: #c678dd;
+    }
+    .token.function {
+      color: #61afef;
+    }
+    .token.regex,
+    .token.important,
+    .token.variable {
+      color: #c678dd;
+    }
+    .token.important,
+    .token.bold {
+      font-weight: bold;
+    }
+    .token.italic {
+      font-style: italic;
+    }
+    .token.entity {
+      cursor: help;
+    }
+    pre.line-numbers {
+      position: relative;
+      padding-left: 3.8em;
+      counter-reset: linenumber;
+    }
+    pre.line-numbers > code {
+      position: relative;
+    }
+    .line-numbers .line-numbers-rows {
+      position: absolute;
+      pointer-events: none;
+      top: 0;
+      font-size: 100%;
+      left: -3.8em;
+      width: 3em; /* works for line-numbers below 1000 lines */
+      letter-spacing: -1px;
+      border-right: 0;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+    }
+    .line-numbers-rows > span {
+      pointer-events: none;
+      display: block;
+      counter-increment: linenumber;
+    }
+    .line-numbers-rows > span:before {
+      content: counter(linenumber);
+      color: #5c6370;
+      display: block;
+      padding-right: 0.8em;
+      text-align: right;
+    }
+  `,
+  markdown: css`
+    background: black;
+  `,
+};
+
+export default prismTheme;


### PR DESCRIPTION
## 관련 이슈

- #50 MarkDownRendering Atomic 컴포넌트 추가
- #51 prism-plugin 적용
- #52 마크다운 에디터 스타일(atom-one-dark)

## 변경 사항

- 게시글 작성 페이지(Write) 뿐만 아니라, 게시글 상세 페이지(PostDetail)에서 본문과 댓글에서도 마크다운 랜더링이 필요합니다. 여러 컴포넌트에서 공통으로 사용되기 때문에, 공통 컴포넌트 폴더(common)에 파일을 배치하였습니다.
- 마크다운 랜더링 과정은 다음과 같습니다.
  - 사용자가 codemirror에서 텍스트를 입력한다
  - codemirror 텍스트를 dispatch에다가 실어서 reducer로 보낸다
  - MarkDownRendering 컴포넌트에서 reducer의 state가 변경되었는지 감지한다
  - 텍스트가 변경되었으면, 아래 과정을 통해 마크다운 텍스트를 html code로 변환시킨다
     - useEffect에서 remark 라이브러리 실행
     - prism.js를 통해 code 부분은 따로 highlight 처리
     - remark-breaks로 텍스트의 줄바꿈 처리 적용
     - remark-html을 통해 html 문서로 변환
     - 변환 된 내용을 useState에다가 보관
     - html-react-parser을 통해, useState에 보관 된 html 텍스트를 jsx 형태로 변환
- jsx로 변환 된 code에다가 style을 적용시키기 위해, atom-one-dark의 css를 사용하였습니다.

## PR Point

- 이름이 어색하거나 부적합다고 판단하는 경우를 중점적으로 확인 부탁 드립니다.

## 참고 사항

- 그 외에 참고가 필요한 부분을 작성합니다.

## Check Point

- [x] 빌드를 직접해서 올려보셨나요?
- [x] 사용하지 않는 변수, import, 함수 등은 없나요?
- [ ] 테스트는 작성하셨나요?
- [ ] 테스트를 돌려보셨나요?
