### PR TITLE
글쓰기 화면 기능 개발

### DIFF
--- a/src/components/Write/EditorPreview/index.tsx
+++ b/src/components/Write/EditorPreview/index.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { useSelector } from "react-redux";
+
+import { rootState } from "@store/index";
+import MarkDownRendering from "@common/Organisms/MarkDownRendering";
+import * as S from "./style";
+
+const EditorPreview = () => {
+  const title = useSelector((state: rootState) => state.write.title);
+  const markDownText = useSelector((state: rootState) => state.write.markDownText);
+
+  return (
+    <>
+      <S.TitleWrapper>{title}</S.TitleWrapper>
+      <MarkDownRendering markDownText={markDownText} />
+    </>
+  );
+};
+
+export default EditorPreview;

--- a/src/components/Write/EditorPreview/style.ts
+++ b/src/components/Write/EditorPreview/style.ts
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const TitleWrapper = styled.h2`
+  font-size: 2.5em;
+  margin-bottom: 4rem;
+  font-weight: 800;
+`;

--- a/src/components/Write/MarkDownEditor/index.tsx
+++ b/src/components/Write/MarkDownEditor/index.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef } from "react";
+import { useDispatch } from "react-redux";
 import codemirror, { EditorFromTextArea } from "codemirror";
+import { changeMarkDownText } from "@store/Write/action";
 
 import "./atom-one-light.css";
 import "codemirror/addon/display/placeholder";
@@ -10,6 +12,7 @@ require("codemirror/mode/javascript/javascript");
 require("codemirror/mode/jsx/jsx");
 
 const MarkDownEditor = () => {
+  const dispatch = useDispatch();
   const codeMirrorRef = useRef<EditorFromTextArea | null>(null);
 
   useEffect(() => {
@@ -22,6 +25,13 @@ const MarkDownEditor = () => {
     });
     window.codeMirror = codeMirrorRef.current;
   }, []);
+
+  useEffect(() => {
+    if (!codeMirrorRef.current) return;
+    codeMirrorRef.current.on("change", (instance) => {
+      dispatch(changeMarkDownText(instance.getValue()));
+    });
+  }, [dispatch]);
 
   return (
     <>

--- a/src/components/Write/TitleInput/index.tsx
+++ b/src/components/Write/TitleInput/index.tsx
@@ -1,0 +1,29 @@
+import React, { useCallback, useRef, useState } from "react";
+import { useDispatch } from "react-redux";
+import { changeMarkDownTitle } from "@store/Write/action";
+import * as S from "./style";
+
+const TitleInput = () => {
+  const dispatch = useDispatch();
+  const [text, setText] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const changeTextarea = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (!textareaRef.current) return;
+      textareaRef.current.style.height = "1px";
+      textareaRef.current.style.height = `${12 + textareaRef.current.scrollHeight}px`;
+      setText(e.target.value);
+      dispatch(changeMarkDownTitle(e.target.value));
+    },
+    [dispatch],
+  );
+
+  return (
+    <>
+      <S.Textarea ref={textareaRef} value={text} onChange={changeTextarea} />
+    </>
+  );
+};
+
+export default TitleInput;

--- a/src/components/Write/TitleInput/style.ts
+++ b/src/components/Write/TitleInput/style.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const Textarea = styled.textarea`
+  resize: none;
+  outline: none;
+  border: 1px solid rgb(233, 236, 239);
+  border-image: initial;
+  border-radius: 4px;
+  overflow-y: hidden;
+`;

--- a/src/pages/write/index.tsx
+++ b/src/pages/write/index.tsx
@@ -1,16 +1,20 @@
 import React from "react";
 
 import EditorFooter from "@components/Write/EditorFooter";
+import EditorPreview from "@components/Write/EditorPreview";
 import EditorToolbar from "@components/Write/EditorToolbar";
 import MarkDownEditor from "@components/Write/MarkDownEditor";
+import TitleInput from "@components/Write/TitleInput";
 
 const Write = () => {
   return (
     <>
       <div>
+        <TitleInput />
         <EditorToolbar />
         <MarkDownEditor />
         <EditorFooter />
+        <EditorPreview />
       </div>
     </>
   );


### PR DESCRIPTION
## 관련 이슈
- #10 글쓰기 화면 기능 개발
- #40 EditorPreview 컴포넌트
- #43 Write/TitleInput 컴포넌트 추가
- #44 Write/MarkDownEditor 리팩토링

## 변경 사항
- 아래와 같은 순서로 컴포넌트가 동작합니다.
  - Write/MarkDownEditor와 Write/TitleInput에서 각각 본문과 제목을 입력합니다.
  - 각 컴포넌트 별로 텍스트가 변경되면 dispatch를 보냅니다
  - Write/EditorPreview에서 각각 변경 된 본문과 제목을 갱신합니다.
    - 본문 텍스트의 경우에는, 하위 컴포넌트인 Organisms/MarkDownRendering에다가 본문 텍스트를 전달합니다.
- pages/Write EditorPreview, TitleInput를 각각 import하여 return 부분에 추가하였습니다.
- Titleinput.tsx에서 제목 부분을 textarea tag로 사용하였습니다. 그리고 textarea의 기본 style을 제거시켰습니다. 이후, 텍스트 길이에 따라서 textarea의 높이를 자동으로 변경하도록 하였습니다.

## PR Point

- 변수명이 어색하거나 불필요해 보이는 로직을 중점적으로 확인 부탁 드립니다.

## 참고 사항

- 그 외에 참고가 필요한 부분을 작성합니다.

## Check Point

- [x] 빌드를 직접해서 올려보셨나요?
- [x] 사용하지 않는 변수, import, 함수 등은 없나요?
- [ ] 테스트는 작성하셨나요?
- [ ] 테스트를 돌려보셨나요?
